### PR TITLE
Update link, :hover and :active colours

### DIFF
--- a/resources/public-assets/stylesheets/govuk-template.css
+++ b/resources/public-assets/stylesheets/govuk-template.css
@@ -133,16 +133,6 @@ fieldset {
   border: none;
   padding: 0; }
 
-a,
-a:visited {
-  color: #2e3191; }
-
-a:hover {
-  color: #2e8aca; }
-
-a:active {
-  color: #2e8aca; }
-
 a[rel="external"]:after {
   background-image: url(external-link.png);
   background-repeat: no-repeat; }

--- a/resources/public-assets/stylesheets/govuk-template.css
+++ b/resources/public-assets/stylesheets/govuk-template.css
@@ -133,6 +133,16 @@ fieldset {
   border: none;
   padding: 0; }
 
+a,
+a:visited {
+  color: #4c2c92; }
+
+a:hover {
+  color: #2b8cc4; }
+
+a:active {
+  color: #2b8cc4; }
+
 a[rel="external"]:after {
   background-image: url(external-link.png);
   background-repeat: no-repeat; }


### PR DESCRIPTION
This pull request updates colours for links, :hover and :active selectors.

Colours should be managed and kept in 1 place in the frontend toolkit. This means they are easier to manage in 1 place and use variables which makes them far more flexible.