### PR TITLE
Added mustache tags to the modernizer.js script tag

### DIFF
--- a/resources/templates/mustache/preprod/govuk-template.mustache.html
+++ b/resources/templates/mustache/preprod/govuk-template.mustache.html
@@ -97,8 +97,12 @@
     {{#optimizelyProjectId}}
     <script src='{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js' type='text/javascript'></script>
     {{/optimizelyProjectId}}
+    {{#assetsPath}}
+    <script src='{{assetsPath}}javascripts/vendor/modernizr.js' type='text/javascript'></script>
+    {{/assetsPath}}
+    {{^assetsPath}}
     <script src='/assets/2.246.0/javascripts/vendor/modernizr.js' type='text/javascript'></script>
-
+    {{/assetsPath}}
 </head>
 
 <body>
@@ -241,7 +245,15 @@
                 </ul>
 
                 <div class="open-government-licence">
-                    <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank"><img src="/assets/2.246.0/images/open-government-licence_2x.png" alt="Open Government Licence"></a></h2>
+                    <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">
+                        {{#assetsPath}}
+                        <img src="{{assetsPath}}images/open-government-licence_2x.png" alt="Open Government Licence">
+                        {{/assetsPath}}
+                        {{^assetsPath}}
+                        <img src="/assets/2.246.0/images/open-government-licence_2x.png" alt="Open Government Licence">
+                        {{/assetsPath}}
+                    </a>
+                    </h2>
                     <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">Open Government Licence v3.0</a>, except where otherwise stated</p>
                 </div>
             </div>

--- a/resources/templates/mustache/production/govuk-template.mustache.html
+++ b/resources/templates/mustache/production/govuk-template.mustache.html
@@ -97,8 +97,12 @@
     {{#optimizelyProjectId}}
     <script src='{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js' type='text/javascript'></script>
     {{/optimizelyProjectId}}
+    {{#assetsPath}}
+    <script src='{{assetsPath}}javascripts/vendor/modernizr.js' type='text/javascript'></script>
+    {{/assetsPath}}
+    {{^assetsPath}}
     <script src='/assets/2.246.0/javascripts/vendor/modernizr.js' type='text/javascript'></script>
-
+    {{/assetsPath}}
 </head>
 
 <body>
@@ -241,7 +245,15 @@
                 </ul>
 
                 <div class="open-government-licence">
-                    <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank"><img src="/assets/2.246.0/images/open-government-licence_2x.png" alt="Open Government Licence"></a></h2>
+                    <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">
+                        {{#assetsPath}}
+                        <img src="{{assetsPath}}images/open-government-licence_2x.png" alt="Open Government Licence">
+                        {{/assetsPath}}
+                        {{^assetsPath}}
+                        <img src="/assets/2.246.0/images/open-government-licence_2x.png" alt="Open Government Licence">
+                        {{/assetsPath}}
+                    </a>
+                    </h2>
                     <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">Open Government Licence v3.0</a>, except where otherwise stated</p>
                 </div>
             </div>


### PR DESCRIPTION
The mustache tags around the modernizr.js script tag were absent so it was always loading the default version from 2.246.0 of assets-frontend and was therefore out of step when frontends were specifying a particular version of AF.

Added mustache tags to allow the modernizer.js script tag to be overridden along with the rest of the AF versioning.