### PR TITLE
SDT-639 Bumped default assets-frontend version to 2.247.0

### DIFF
--- a/resources/templates/mustache/preprod/govuk-template.mustache.html
+++ b/resources/templates/mustache/preprod/govuk-template.mustache.html
@@ -67,7 +67,7 @@
     <link rel='stylesheet' href='{{assetsPath}}stylesheets/application-ie7.min.css' />
     {{/assetsPath}}
     {{^assetsPath}}
-    <link rel='stylesheet' href='/assets/2.246.0/stylesheets/application-ie7.min.css' />
+    <link rel='stylesheet' href='/assets/2.247.0/stylesheets/application-ie7.min.css' />
     {{/assetsPath}}
     <![endif]-->
     <!--[if IE 8 ]>
@@ -75,7 +75,7 @@
     <link rel='stylesheet' href='{{assetsPath}}stylesheets/application-ie.min.css' />
     {{/assetsPath}}
     {{^assetsPath}}
-    <link rel='stylesheet' href='/assets/2.246.0/stylesheets/application-ie.min.css' />
+    <link rel='stylesheet' href='/assets/2.247.0/stylesheets/application-ie.min.css' />
     {{/assetsPath}}
     <![endif]-->
     <!--[if gt IE 8]><!-->
@@ -83,7 +83,7 @@
     <link rel='stylesheet' href='{{assetsPath}}stylesheets/application.min.css' />
     {{/assetsPath}}
     {{^assetsPath}}
-    <link rel='stylesheet' href='/assets/2.246.0/stylesheets/application.min.css' />
+    <link rel='stylesheet' href='/assets/2.247.0/stylesheets/application.min.css' />
     {{/assetsPath}}
     <!--<![endif]-->
 
@@ -101,7 +101,7 @@
     <script src='{{assetsPath}}javascripts/vendor/modernizr.js' type='text/javascript'></script>
     {{/assetsPath}}
     {{^assetsPath}}
-    <script src='/assets/2.246.0/javascripts/vendor/modernizr.js' type='text/javascript'></script>
+    <script src='/assets/2.247.0/javascripts/vendor/modernizr.js' type='text/javascript'></script>
     {{/assetsPath}}
 </head>
 
@@ -250,7 +250,7 @@
                         <img src="{{assetsPath}}images/open-government-licence_2x.png" alt="Open Government Licence">
                         {{/assetsPath}}
                         {{^assetsPath}}
-                        <img src="/assets/2.246.0/images/open-government-licence_2x.png" alt="Open Government Licence">
+                        <img src="/assets/2.247.0/images/open-government-licence_2x.png" alt="Open Government Licence">
                         {{/assetsPath}}
                     </a>
                     </h2>
@@ -299,7 +299,7 @@
 <script src="{{assetsPath}}javascripts/application.min.js" type="text/javascript"></script>
 {{/assetsPath}}
 {{^assetsPath}}
-<script src="/assets/2.246.0/javascripts/application.min.js" type="text/javascript"></script>
+<script src="/assets/2.247.0/javascripts/application.min.js" type="text/javascript"></script>
 {{/assetsPath}}
 
 <!--<script src="/template/assets/javascripts/govuk-template.js" type="text/javascript"></script>-->

--- a/resources/templates/mustache/production/govuk-template.mustache.html
+++ b/resources/templates/mustache/production/govuk-template.mustache.html
@@ -67,7 +67,7 @@
     <link rel='stylesheet' href='{{assetsPath}}stylesheets/application-ie7.min.css' />
     {{/assetsPath}}
     {{^assetsPath}}
-    <link rel='stylesheet' href='/assets/2.246.0/stylesheets/application-ie7.min.css' />
+    <link rel='stylesheet' href='/assets/2.247.0/stylesheets/application-ie7.min.css' />
     {{/assetsPath}}
     <![endif]-->
     <!--[if IE 8 ]>
@@ -75,7 +75,7 @@
     <link rel='stylesheet' href='{{assetsPath}}stylesheets/application-ie.min.css' />
     {{/assetsPath}}
     {{^assetsPath}}
-    <link rel='stylesheet' href='/assets/2.246.0/stylesheets/application-ie.min.css' />
+    <link rel='stylesheet' href='/assets/2.247.0/stylesheets/application-ie.min.css' />
     {{/assetsPath}}
     <![endif]-->
     <!--[if gt IE 8]><!-->
@@ -83,7 +83,7 @@
     <link rel='stylesheet' href='{{assetsPath}}stylesheets/application.min.css' />
     {{/assetsPath}}
     {{^assetsPath}}
-    <link rel='stylesheet' href='/assets/2.246.0/stylesheets/application.min.css' />
+    <link rel='stylesheet' href='/assets/2.247.0/stylesheets/application.min.css' />
     {{/assetsPath}}
     <!--<![endif]-->
 
@@ -101,7 +101,7 @@
     <script src='{{assetsPath}}javascripts/vendor/modernizr.js' type='text/javascript'></script>
     {{/assetsPath}}
     {{^assetsPath}}
-    <script src='/assets/2.246.0/javascripts/vendor/modernizr.js' type='text/javascript'></script>
+    <script src='/assets/2.247.0/javascripts/vendor/modernizr.js' type='text/javascript'></script>
     {{/assetsPath}}
 </head>
 
@@ -250,7 +250,7 @@
                         <img src="{{assetsPath}}images/open-government-licence_2x.png" alt="Open Government Licence">
                         {{/assetsPath}}
                         {{^assetsPath}}
-                        <img src="/assets/2.246.0/images/open-government-licence_2x.png" alt="Open Government Licence">
+                        <img src="/assets/2.247.0/images/open-government-licence_2x.png" alt="Open Government Licence">
                         {{/assetsPath}}
                     </a>
                     </h2>
@@ -299,7 +299,7 @@
 <script src="{{assetsPath}}javascripts/application.min.js" type="text/javascript"></script>
 {{/assetsPath}}
 {{^assetsPath}}
-<script src="/assets/2.246.0/javascripts/application.min.js" type="text/javascript"></script>
+<script src="/assets/2.247.0/javascripts/application.min.js" type="text/javascript"></script>
 {{/assetsPath}}
 
 <!--<script src="/template/assets/javascripts/govuk-template.js" type="text/javascript"></script>-->


### PR DESCRIPTION
Bumped the default assets-frontend version in the template to 2.247.0.

This version of assets-frontend contains the latest design of radio buttons and checkboxes from GDS alongside the existing versions.