### PR TITLE
Introduce facility for custom GA configuration, pre 'pageview' event

### DIFF
--- a/resources/templates/mustache/preprod/govuk-template.mustache.html
+++ b/resources/templates/mustache/preprod/govuk-template.mustache.html
@@ -698,6 +698,9 @@
             {{#iycdcReconciliationStatus}}                  ga('set', 'dimension55', '{{{iycdcReconciliationStatus}}}');                  {{/iycdcReconciliationStatus}}
             {{#p800Type}}                                   ga('set', 'dimension56', '{{{p800Type}}}');                                   {{/p800Type}}
 
+            {{#gaCustomEvent}}
+                {{{gaCustomEvent}}}
+            {{/gaCustomEvent}}
 
             ga('send', 'pageview');
             ga('set', 'nonInteraction', true);

--- a/resources/templates/mustache/production/govuk-template.mustache.html
+++ b/resources/templates/mustache/production/govuk-template.mustache.html
@@ -698,6 +698,9 @@
             {{#iycdcReconciliationStatus}}                  ga('set', 'dimension55', '{{{iycdcReconciliationStatus}}}');                  {{/iycdcReconciliationStatus}}
             {{#p800Type}}                                   ga('set', 'dimension56', '{{{p800Type}}}');                                   {{/p800Type}}
 
+            {{#gaCustomEvent}}
+                {{{gaCustomEvent}}}
+            {{/gaCustomEvent}}
 
             ga('send', 'pageview');
             ga('set', 'nonInteraction', true);


### PR DESCRIPTION
Discussed with Nic Fellows short while back.
The facility allows us to override the page title (which may contain personal information) with a GA compliant version (no personal info within).