### PR TITLE
Adding flag for optimizely audience

### DIFF
--- a/resources/templates/mustache/preprod/govuk-template.mustache.html
+++ b/resources/templates/mustache/preprod/govuk-template.mustache.html
@@ -106,14 +106,14 @@
     {{/optimizelyProjectId}}
 
     {{#optimizely}}
-        {{#optimizelyAudience}}
+        {{#audience}}
             <script type="text/javascript">
-                var optimizelyAudience = "{{optimizelyAudience}}"
+                var audience = "{{audience}}"
             </script>
-        {{/optimizelyAudience}}
-        {{#optimizelyProjectId}}
-            <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
-        {{/optimizelyProjectId}}
+        {{/audience}}
+        {{#projectId}}
+            <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{projectId}}}.js" type="text/javascript"></script>
+        {{/projectId}}
     {{/optimizely}}
 
     {{#assetsPath}}

--- a/resources/templates/mustache/preprod/govuk-template.mustache.html
+++ b/resources/templates/mustache/preprod/govuk-template.mustache.html
@@ -102,6 +102,11 @@
     {{/linkElems}}
 
     {{#optimizelyProjectId}}
+        {{#optimizelyAudience}}
+            <script type="text/javascript">
+                var optimizelyAudience = "{{optimizelyAudience}}"
+            </script>
+        {{/optimizelyAudience}}
         <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
     {{/optimizelyProjectId}}
 

--- a/resources/templates/mustache/preprod/govuk-template.mustache.html
+++ b/resources/templates/mustache/preprod/govuk-template.mustache.html
@@ -102,13 +102,19 @@
     {{/linkElems}}
 
     {{#optimizelyProjectId}}
+        <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
+    {{/optimizelyProjectId}}
+
+    {{#optimizely}}
         {{#optimizelyAudience}}
             <script type="text/javascript">
                 var optimizelyAudience = "{{optimizelyAudience}}"
             </script>
         {{/optimizelyAudience}}
-        <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
-    {{/optimizelyProjectId}}
+        {{#optimizelyProjectId}}
+            <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
+        {{/optimizelyProjectId}}
+    {{/optimizely}}
 
     {{#assetsPath}}
         <script src="{{assetsPath}}javascripts/vendor/modernizr.js" type="text/javascript"></script>

--- a/resources/templates/mustache/production/govuk-template.mustache.html
+++ b/resources/templates/mustache/production/govuk-template.mustache.html
@@ -106,14 +106,14 @@
     {{/optimizelyProjectId}}
 
     {{#optimizely}}
-        {{#optimizelyAudience}}
+        {{#audience}}
             <script type="text/javascript">
-                var optimizelyAudience = "{{optimizelyAudience}}"
+                var audience = "{{audience}}"
             </script>
-        {{/optimizelyAudience}}
-        {{#optimizelyProjectId}}
-            <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
-        {{/optimizelyProjectId}}
+        {{/audience}}
+        {{#projectId}}
+            <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{projectId}}}.js" type="text/javascript"></script>
+        {{/projectId}}
     {{/optimizely}}
 
     {{#assetsPath}}

--- a/resources/templates/mustache/production/govuk-template.mustache.html
+++ b/resources/templates/mustache/production/govuk-template.mustache.html
@@ -102,6 +102,11 @@
     {{/linkElems}}
 
     {{#optimizelyProjectId}}
+        {{#optimizelyAudience}}
+            <script type="text/javascript">
+                var optimizelyAudience = "{{optimizelyAudience}}"
+            </script>
+        {{/optimizelyAudience}}
         <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
     {{/optimizelyProjectId}}
 

--- a/resources/templates/mustache/production/govuk-template.mustache.html
+++ b/resources/templates/mustache/production/govuk-template.mustache.html
@@ -102,13 +102,19 @@
     {{/linkElems}}
 
     {{#optimizelyProjectId}}
+        <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
+    {{/optimizelyProjectId}}
+
+    {{#optimizely}}
         {{#optimizelyAudience}}
             <script type="text/javascript">
                 var optimizelyAudience = "{{optimizelyAudience}}"
             </script>
         {{/optimizelyAudience}}
-        <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
-    {{/optimizelyProjectId}}
+        {{#optimizelyProjectId}}
+            <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
+        {{/optimizelyProjectId}}
+    {{/optimizely}}
 
     {{#assetsPath}}
         <script src="{{assetsPath}}javascripts/vendor/modernizr.js" type="text/javascript"></script>


### PR DESCRIPTION
Adding optional flag so services can add a custom audience for optimizely. Resolves [Issue#47](https://github.com/hmrc/frontend-template-provider/issues/47)