### PR TITLE
ST-261 ST-240: Add ga action for dimension 78 and 76

### DIFF
--- a/resources/templates/mustache/preprod/govuk-template.mustache.html
+++ b/resources/templates/mustache/preprod/govuk-template.mustache.html
@@ -818,6 +818,7 @@
             {{#iycdcReconciliationStatus}}                  ga('set', 'dimension55', '{{{iycdcReconciliationStatus}}}');                  {{/iycdcReconciliationStatus}}
             {{#p800Type}}                                   ga('set', 'dimension56', '{{{p800Type}}}');                                   {{/p800Type}}
             {{#p800TaxYearSpan}}                            ga('set', 'dimension69', '{{{p800TaxYearSpan}}}');                            {{/p800TaxYearSpan}}
+            {{#taxCodeChangeDate}}                          ga('set', 'dimension76', '{{{taxCodeChangeDate}}}');                          {{/taxCodeChangeDate}}
             {{#taxCodeChangeEdgeCase}}                      ga('set', 'dimension78', '{{{taxCodeChangeEdgeCase}}}');                      {{/taxCodeChangeEdgeCase}}
 
             {{#gaCustomEvent}}

--- a/resources/templates/mustache/preprod/govuk-template.mustache.html
+++ b/resources/templates/mustache/preprod/govuk-template.mustache.html
@@ -818,6 +818,7 @@
             {{#iycdcReconciliationStatus}}                  ga('set', 'dimension55', '{{{iycdcReconciliationStatus}}}');                  {{/iycdcReconciliationStatus}}
             {{#p800Type}}                                   ga('set', 'dimension56', '{{{p800Type}}}');                                   {{/p800Type}}
             {{#p800TaxYearSpan}}                            ga('set', 'dimension69', '{{{p800TaxYearSpan}}}');                            {{/p800TaxYearSpan}}
+            {{#taxCodeChangeEdgeCase}}                      ga('set', 'dimension78', '{{{taxCodeChangeEdgeCase}}}');                      {{/taxCodeChangeEdgeCase}}
 
             {{#gaCustomEvent}}
                 {{{gaCustomEvent}}}

--- a/resources/templates/mustache/production/govuk-template.mustache.html
+++ b/resources/templates/mustache/production/govuk-template.mustache.html
@@ -818,6 +818,7 @@
             {{#iycdcReconciliationStatus}}                  ga('set', 'dimension55', '{{{iycdcReconciliationStatus}}}');                  {{/iycdcReconciliationStatus}}
             {{#p800Type}}                                   ga('set', 'dimension56', '{{{p800Type}}}');                                   {{/p800Type}}
             {{#p800TaxYearSpan}}                            ga('set', 'dimension69', '{{{p800TaxYearSpan}}}');                            {{/p800TaxYearSpan}}
+            {{#taxCodeChangeDate}}                          ga('set', 'dimension76', '{{{taxCodeChangeDate}}}');                          {{/taxCodeChangeDate}}
             {{#taxCodeChangeEdgeCase}}                      ga('set', 'dimension78', '{{{taxCodeChangeEdgeCase}}}');                      {{/taxCodeChangeEdgeCase}}
 
             {{#gaCustomEvent}}

--- a/resources/templates/mustache/production/govuk-template.mustache.html
+++ b/resources/templates/mustache/production/govuk-template.mustache.html
@@ -818,6 +818,7 @@
             {{#iycdcReconciliationStatus}}                  ga('set', 'dimension55', '{{{iycdcReconciliationStatus}}}');                  {{/iycdcReconciliationStatus}}
             {{#p800Type}}                                   ga('set', 'dimension56', '{{{p800Type}}}');                                   {{/p800Type}}
             {{#p800TaxYearSpan}}                            ga('set', 'dimension69', '{{{p800TaxYearSpan}}}');                            {{/p800TaxYearSpan}}
+            {{#taxCodeChangeEdgeCase}}                      ga('set', 'dimension78', '{{{taxCodeChangeEdgeCase}}}');                      {{/taxCodeChangeEdgeCase}}
 
             {{#gaCustomEvent}}
                 {{{gaCustomEvent}}}


### PR DESCRIPTION
This  adds the set for the GA custom dimensions 76 and 77. See related work: https://github.com/hmrc/tai-frontend/pull/179