### PR TITLE
PLATOPS-1619: Upgrade to Play 2.5.19

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,14 @@ lazy val library = Project(appName, file("."))
     majorVersion := 5,
     makePublicallyAvailableOnBintray := true,
     name := appName,
-    scalaVersion := "2.11.7",
+    scalaVersion := "2.11.12",
     libraryDependencies ++= LibDependencies.compile ++ LibDependencies.test,
     dependencyOverrides ++= LibDependencies.overrides,
     resolvers := Seq(
       Resolver.bintrayRepo("hmrc", "releases"),
       Resolver.typesafeRepo("releases")
     ),
-    crossScalaVersions := Seq("2.11.7"),
+    crossScalaVersions := Seq("2.11.12"),
     routesGenerator    := {
       if (PlayCrossCompilation.playVersion == Play25) {
         StaticRoutesGenerator

--- a/project/LibDependencies.scala
+++ b/project/LibDependencies.scala
@@ -1,12 +1,11 @@
-import sbt.ModuleID
-import sbt._
+import sbt.{ModuleID, _}
 
 object LibDependencies {
 
   val compile: Seq[ModuleID] =
     PlayCrossCompilation.dependencies(
       play25 = Seq(
-        "com.typesafe.play" %% "play" % "2.5.12" % "provided"
+        "com.typesafe.play" %% "play" % "2.5.19" % "provided"
       ),
       play26 = Seq(
         "com.typesafe.play" %% "play" % "2.6.20" % "provided"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,13 +8,13 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.13.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.15.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.14.0")
 
 val playPlugin =
   if (sys.env.get("PLAY_VERSION").exists(_ == "2.6"))
     "com.typesafe.play" % "sbt-plugin" % "2.6.20"
   else
-    "com.typesafe.play" % "sbt-plugin" % "2.5.12"
+    "com.typesafe.play" % "sbt-plugin" % "2.5.19"
 
 addSbtPlugin(playPlugin)
 


### PR DESCRIPTION
We have had to update all the libraries on the platform to use Play 2.5.19 to address a security vulnerability with a version of logback that is included in play (< 2.5.14) which is fixed in play 2.5.19.