### PR TITLE
APIS-4250 Added rel="noopener noferrer" to third party links.

### DIFF
--- a/resources/templates/mustache/preprod/govuk-template.mustache.html
+++ b/resources/templates/mustache/preprod/govuk-template.mustache.html
@@ -713,7 +713,7 @@
                         </li>
                     {{/termsAndConditionFooterLink}}
                     <li>
-                        <a href="https://www.gov.uk/help" target="_blank" data-sso="false" data-journey-click="footer:Click:Help">
+                        <a href="https://www.gov.uk/help" target="_blank" rel="noopener noreferrer" data-sso="false" data-journey-click="footer:Click:Help">
 
                             {{#isWelsh}}
                                 Help wrth ddefnyddio GOV.UK
@@ -736,7 +736,7 @@
                 </ul>
 
                 <div class="open-government-licence">
-                    <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">
+                    <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank" rel="noopener noreferrer">
 
                         <img src="/template/assets/images/open-government-licence_2x.png" alt="Open Government Licence">
 
@@ -745,11 +745,11 @@
                     <p>
 
                         {{#isWelsh}}
-                            Mae&#39;r holl gynnwys ar gael dan y <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">Drwydded Llywodraeth Agored, fersiwn 3.0</a>, oni nodir yn wahanol
+                            Mae&#39;r holl gynnwys ar gael dan y <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank" rel="noopener noreferrer">Drwydded Llywodraeth Agored, fersiwn 3.0</a>, oni nodir yn wahanol
                         {{/isWelsh}}
 
                         {{^isWelsh}}
-                            All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">Open Government Licence v3.0</a>, except where otherwise stated
+                            All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank" rel="noopener noreferrer">Open Government Licence v3.0</a>, except where otherwise stated
                         {{/isWelsh}}
 
                     </p>
@@ -757,7 +757,7 @@
             </div>
 
             <div class="copyright">
-                <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm" target="_blank">
+                <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm" target="_blank" rel="noopener noreferrer">
 
                     {{#isWelsh}}
                         &copy; Hawlfraint y Goron

--- a/resources/templates/mustache/production/govuk-template.mustache.html
+++ b/resources/templates/mustache/production/govuk-template.mustache.html
@@ -713,7 +713,7 @@
                         </li>
                     {{/termsAndConditionFooterLink}}
                     <li>
-                        <a href="https://www.gov.uk/help" target="_blank" data-sso="false" data-journey-click="footer:Click:Help">
+                        <a href="https://www.gov.uk/help" target="_blank" rel="noopener noreferrer" data-sso="false" data-journey-click="footer:Click:Help">
 
                             {{#isWelsh}}
                                 Help wrth ddefnyddio GOV.UK
@@ -736,7 +736,7 @@
                 </ul>
 
                 <div class="open-government-licence">
-                    <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">
+                    <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank" rel="noopener noreferrer">
 
                         <img src="/template/assets/images/open-government-licence_2x.png" alt="Open Government Licence">
 
@@ -745,11 +745,11 @@
                     <p>
 
                         {{#isWelsh}}
-                            Mae&#39;r holl gynnwys ar gael dan y <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">Drwydded Llywodraeth Agored, fersiwn 3.0</a>, oni nodir yn wahanol
+                            Mae&#39;r holl gynnwys ar gael dan y <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank" rel="noopener noreferrer">Drwydded Llywodraeth Agored, fersiwn 3.0</a>, oni nodir yn wahanol
                         {{/isWelsh}}
 
                         {{^isWelsh}}
-                            All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">Open Government Licence v3.0</a>, except where otherwise stated
+                            All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank" rel="noopener noreferrer">Open Government Licence v3.0</a>, except where otherwise stated
                         {{/isWelsh}}
 
                     </p>
@@ -757,7 +757,7 @@
             </div>
 
             <div class="copyright">
-                <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm" target="_blank">
+                <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm" target="_blank" rel="noopener noreferrer">
 
                     {{#isWelsh}}
                         &copy; Hawlfraint y Goron

--- a/src/main/play-25/twirl/views/layouts/govuk_template.scala.html
+++ b/src/main/play-25/twirl/views/layouts/govuk_template.scala.html
@@ -129,13 +129,13 @@
                         @footerLinks.getOrElse("")
 
                         <div class="open-government-licence">
-                            <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank"><img src="@routes.Template.at("images/open-government-licence_2x.png")" alt="Open Government Licence"></a></h2>
-                            <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">Open Government Licence v3.0</a>, except where otherwise stated</p>
+                            <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank" rel="noopener noreferrer"><img src="@routes.Template.at("images/open-government-licence_2x.png")" alt="Open Government Licence"></a></h2>
+                            <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank" rel="noopener noreferrer">Open Government Licence v3.0</a>, except where otherwise stated</p>
                         </div>
                     </div>
 
                     <div class="copyright">
-                        <a href="https://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm" target="_blank">&copy; Crown Copyright</a>
+                        <a href="https://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm" target="_blank" rel="noopener noreferrer">&copy; Crown Copyright</a>
                     </div>
                 </div>
             </div>

--- a/src/main/play-26/twirl/views/layouts/GovUkTemplate.scala.html
+++ b/src/main/play-26/twirl/views/layouts/GovUkTemplate.scala.html
@@ -131,13 +131,13 @@
                         @footerLinks.getOrElse("")
 
                         <div class="open-government-licence">
-                            <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank"><img src="@routes.Template.at("images/open-government-licence_2x.png")" alt="Open Government Licence"></a></h2>
-                            <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">Open Government Licence v3.0</a>, except where otherwise stated</p>
+                            <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank" rel="noopener noreferrer"><img src="@routes.Template.at("images/open-government-licence_2x.png")" alt="Open Government Licence"></a></h2>
+                            <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank" rel="noopener noreferrer">Open Government Licence v3.0</a>, except where otherwise stated</p>
                         </div>
                     </div>
 
                     <div class="copyright">
-                        <a href="https://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm" target="_blank">&copy; Crown Copyright</a>
+                        <a href="https://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm" target="_blank" rel="noopener noreferrer">&copy; Crown Copyright</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This is to mitigate against tabnabbing exploits.