### PR TITLE
Accessibility link translates into Welsh and opens in new window

### DIFF
--- a/resources/templates/mustache/production/govuk-template.mustache.html
+++ b/resources/templates/mustache/production/govuk-template.mustache.html
@@ -653,7 +653,15 @@
 
                             {{#accessibilityFooterUrl}}
                                 <li>
-                                    <a href="{{accessibilityFooterUrl}}" data-sso="false" data-journey-click="footer:Click:Accessibility">Accessibility</a>
+                                    <a href="{{accessibilityFooterUrl}}" target="_blank" data-sso="false" data-journey-click="footer:Click:Accessibility">
+                                        {{#isWelsh}}
+                                            Datganiad
+                                        {{/isWelsh}}
+                                        
+                                        {{^isWelsh}}
+                                            Accessibility
+                                        {{/isWelsh}}
+                                    </a>
                                 </li>
                             {{/accessibilityFooterUrl}}
 


### PR DESCRIPTION
This is needed as our service supports Welsh, so the link text needs to translate into Welsh and open in a new window