### PR TITLE
DL-2409 Updated Accessibility link to open in the same/current page

### DIFF
--- a/resources/templates/mustache/production/govuk-template.mustache.html
+++ b/resources/templates/mustache/production/govuk-template.mustache.html
@@ -653,7 +653,7 @@
 
                             {{#accessibilityFooterUrl}}
                                 <li>
-                                    <a href="{{accessibilityFooterUrl}}" target="_blank" data-sso="false" data-journey-click="footer:Click:Accessibility">
+                                    <a href="{{accessibilityFooterUrl}}" data-sso="false" data-journey-click="footer:Click:Accessibility">
                                         {{#isWelsh}}
                                             Datganiad
                                         {{/isWelsh}}


### PR DESCRIPTION
Currently the link to accessibility statement in the footer opens in a new tab/window. As per HMRC Accessibility Champion's (Chris Moore) instructions we need to make sure the accessibility statement opens in the same page where it is clicked.